### PR TITLE
Security issue with export options

### DIFF
--- a/classes/class.wp-megamenu-export-import.php
+++ b/classes/class.wp-megamenu-export-import.php
@@ -24,8 +24,8 @@ if ( ! class_exists('WP_MegaMenu_Export_Import')){
 			
 			$wpmmm_nav_export_nonce_field = isset($_POST['wpmmm_nav_export_nonce_field']) ? $_POST['wpmmm_nav_export_nonce_field'] : false;
 
-			if(! current_user_can('administrator') && ! isset( $_POST['wpmmm_nav_export_nonce_field'] ) && ! wp_verify_nonce( $wpmmm_nav_export_nonce_field, 'wpmmm_nav_export_action' ) ){
-                wp_die('Sorry, you are not allowed to access this page.');
+			if(! current_user_can('administrator') || ! isset( $_POST['wpmmm_nav_export_nonce_field'] ) || ! wp_verify_nonce( $wpmmm_nav_export_nonce_field, 'wpmmm_nav_export_action' ) ){
+                return;
 			}
 			
 			if ( ! isset($_GET['action']) || $_GET['action'] !== 'wp_megamenu_nav_export'){

--- a/classes/class.wp-megamenu-themes.php
+++ b/classes/class.wp-megamenu-themes.php
@@ -77,11 +77,11 @@ if ( ! class_exists('wp_megamenu_themes')) {
         }
 
         public function export_theme(){
-
+            
             $wpmmm_save_new_theme_nonce_field = isset($_POST['wpmmm_save_new_theme_nonce_field']) ? $_POST['wpmmm_save_new_theme_nonce_field'] : false;
 
-            if(! current_user_can('administrator') && ! isset( $_POST['wpmmm_save_new_theme_nonce_field'] ) && ! wp_verify_nonce( $wpmmm_save_new_theme_nonce_field, 'wpmmm_save_new_theme_action' ) ){
-                wp_die('Sorry, you are not allowed to access this page.');
+            if(! current_user_can('administrator') || ! isset( $_POST['wpmmm_save_new_theme_nonce_field'] ) || ! wp_verify_nonce( $wpmmm_save_new_theme_nonce_field, 'wpmmm_save_new_theme_action' ) ){
+                return;
 			}
             if ( ! empty($_GET['action']) && $_GET['action'] === 'export_wpmm_theme' && ! empty($_GET['theme_id'])){
                 


### PR DESCRIPTION
Two serious security issues are taken care for capability and CSRF due to a logic flaw, in its "theme" export and "megamenu nav menu" export methods which is hooked to admin_init. After applying this fix unauthenticated users can call them and access arbitrary post data, including password protected or private ones.
